### PR TITLE
API:Redirects sample code

### DIFF
--- a/get_redirects.py
+++ b/get_redirects.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+"""
+    get_redirects.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Redirects` module
+    MIT license
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    'action':"query",
+    'format':"json",
+    'titles':"Main Page",
+    'prop': "redirects"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
This is sample code for the page on API:Redirects.

The commit message is a little weird because I had to force push to remove the commits from API:Lists

[www.mediawiki.org/wiki/User:Martyav/Sandbox/API:Redirects](www.mediawiki.org/wiki/User:Martyav/Sandbox/API:Redirects)